### PR TITLE
Add option to force a migration up or down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To toggle a migration (useful while writing your migration):
 To migrate up:
 
 ```sh
-./mongrate up 20140523_UpdateAddressStructure
+./mongrate up 20140523_UpdateAddressStructure [--force]
 ```
 
 ## Migrate down
@@ -104,7 +104,7 @@ To migrate up:
 To migrate down:
 
 ```sh
-./mongrate down 20140523_UpdateAddressStructure
+./mongrate down 20140523_UpdateAddressStructure [--force]
 ```
 
 ## Test Migration

--- a/src/Mongrate/Command/DownCommand.php
+++ b/src/Mongrate/Command/DownCommand.php
@@ -5,6 +5,7 @@ namespace Mongrate\Command;
 use Mongrate\Exception\CannotApplyException;
 use Mongrate\Migration\Direction;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DownCommand extends BaseMigrationCommand
@@ -12,7 +13,15 @@ class DownCommand extends BaseMigrationCommand
     protected function configure()
     {
         $this->setName('down')
-            ->setDescription('Revert your migration - execute the down method of your migration.');
+            ->setDescription('Revert your migration - execute the down method of your migration.')
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Force going down, even if the migration has not been applied yet.',
+                false
+            )
+        ;
 
         parent::configure();
     }
@@ -23,7 +32,9 @@ class DownCommand extends BaseMigrationCommand
 
         $isAlreadyApplied = $this->isMigrationApplied($this->className);
 
-        if ($isAlreadyApplied === false) {
+        $force = $input->getOption('force');
+
+        if ($isAlreadyApplied === false && !$force) {
             throw new CannotApplyException('Cannot go down - the migration is not applied yet.');
         } else {
             $this->migrate(Direction::down());

--- a/src/Mongrate/Command/UpCommand.php
+++ b/src/Mongrate/Command/UpCommand.php
@@ -5,6 +5,7 @@ namespace Mongrate\Command;
 use Mongrate\Exception\CannotApplyException;
 use Mongrate\Migration\Direction;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpCommand extends BaseMigrationCommand
@@ -12,7 +13,14 @@ class UpCommand extends BaseMigrationCommand
     protected function configure()
     {
         $this->setName('up')
-            ->setDescription('Apply your migration - execute `up` method of your migration.');
+            ->setDescription('Apply your migration - execute `up` method of your migration.')
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Force going up, even if the migration has already been applied.',
+                false
+            )
         ;
 
         parent::configure();
@@ -24,7 +32,9 @@ class UpCommand extends BaseMigrationCommand
 
         $isAlreadyApplied = $this->isMigrationApplied($this->className);
 
-        if ($isAlreadyApplied === true) {
+        $force = $input->getOption('force');
+
+        if ($isAlreadyApplied === true && !$force) {
             throw new CannotApplyException('Cannot go up - the migration is already applied.');
         } else {
             $this->migrate(Direction::up());

--- a/test/Mongrate/Tests/Command/DownCommandTest.php
+++ b/test/Mongrate/Tests/Command/DownCommandTest.php
@@ -33,9 +33,11 @@ class DownCommandTest extends BaseCommandTest
 
         // Run the command.
         $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure']);
-        $this->assertEquals("Migrating down... UpdateAddressStructure\n"
-                ."Migrated down\n",
-            $commandTester->getDisplay());
+        $this->assertEquals(
+            "Migrating down... UpdateAddressStructure\n"
+            ."Migrated down\n",
+            $commandTester->getDisplay()
+        );
 
         // Now has an array of addresses at the root of 'address'.
         $this->assertArrayHasKey(0, $collection->findOne(['name' => 'Bob'])['address']);
@@ -68,5 +70,19 @@ class DownCommandTest extends BaseCommandTest
 
         $this->setExpectedException('Mongrate\Exception\CannotApplyException', 'Cannot go down - the migration is not applied yet.');
         $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure']);
+    }
+
+    public function testExecute_forceApply()
+    {
+        $application = new Application();
+        $application->add(new DownCommand(null, $this->parametersFromYmlFile));
+        $command = $application->find('down');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure']);
+        $this->assertContains("Migrated down", $commandTester->getDisplay());
+
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure', '-f' => true]);
+        $this->assertContains("Migrated down", $commandTester->getDisplay());
     }
 }

--- a/test/Mongrate/Tests/Command/UpCommandTest.php
+++ b/test/Mongrate/Tests/Command/UpCommandTest.php
@@ -34,9 +34,11 @@ class UpCommandTest extends BaseCommandTest
 
         // Run the command.
         $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure']);
-        $this->assertEquals("Migrating up... UpdateAddressStructure\n"
-                ."Migrated up\n",
-            $commandTester->getDisplay());
+        $this->assertEquals(
+            "Migrating up... UpdateAddressStructure\n"
+            ."Migrated up\n",
+            $commandTester->getDisplay()
+        );
 
         // Now only has the first address at the root of 'address'.
         $this->assertArrayHasKey('streetFirstLine', $collection->findOne(['name' => 'Amy'])['address']);
@@ -69,5 +71,19 @@ class UpCommandTest extends BaseCommandTest
 
         $this->setExpectedException('Mongrate\Exception\CannotApplyException', 'Cannot go up - the migration is already applied.');
         $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure']);
+    }
+
+    public function testExecute_forceApply()
+    {
+        $application = new Application();
+        $application->add(new UpCommand(null, $this->parametersFromYmlFile));
+        $command = $application->find('up');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure']);
+        $this->assertContains("Migrated up", $commandTester->getDisplay());
+
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'UpdateAddressStructure', '--force' => true]);
+        $this->assertContains("Migrated up", $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
This can be useful in situations where a migration is written in a way
that allows it to be run multiple times, and it needs to be run again.

Completes #23.